### PR TITLE
compute grid size in rt kernels and improve gas optics

### DIFF
--- a/include_rt/Gas_optics_rrtmgp_rt.h
+++ b/include_rt/Gas_optics_rrtmgp_rt.h
@@ -321,6 +321,10 @@ class Gas_optics_rrtmgp_rt : public Gas_optics_rt
                 const Array_gpu<Float,5>& fmajor,
                 Source_func_lw_rt& sources,
                 const Array_gpu<Float,2>& tlev);
+
+        void find_relevant_gases_gpt(
+            const int igpt,
+            std::vector<int>& gases);
 };
 #endif
 

--- a/include_rt/Gas_optics_rrtmgp_rt.h
+++ b/include_rt/Gas_optics_rrtmgp_rt.h
@@ -141,7 +141,7 @@ class Gas_optics_rrtmgp_rt : public Gas_optics_rt
 
         // Longwave variant.
         void gas_optics(
-                const int igpt,
+                const int igpt, const int col_s, const int ncol_block, const int ncol,
                 const Array_gpu<Float,2>& play,
                 const Array_gpu<Float,2>& plev,
                 const Array_gpu<Float,2>& tlay,
@@ -154,7 +154,7 @@ class Gas_optics_rrtmgp_rt : public Gas_optics_rt
 
         // shortwave variant
         void gas_optics(
-                const int igpt,
+                const int igpt, const int col_s, const int ncol_block, const int ncol,
                 const Array_gpu<Float,2>& play,
                 const Array_gpu<Float,2>& plev,
                 const Array_gpu<Float,2>& tlay,
@@ -294,7 +294,8 @@ class Gas_optics_rrtmgp_rt : public Gas_optics_rt
                 const Float md_index, const Float sb_index);
 
         void compute_gas_taus(
-                const int ncol, const int nlay, const int ngpt, const int nband, const int igpt,
+                const int col_s, const int ncol_block, const int ncol, const int nlay, 
+                const int ngpt, const int nband, const int igpt,
                 const Array_gpu<Float,2>& play,
                 const Array_gpu<Float,2>& plev,
                 const Array_gpu<Float,2>& tlay,

--- a/include_rt/Gas_optics_rrtmgp_rt.h
+++ b/include_rt/Gas_optics_rrtmgp_rt.h
@@ -301,9 +301,9 @@ class Gas_optics_rrtmgp_rt : public Gas_optics_rt
                 const Gas_concs_gpu& gas_desc,
                 std::unique_ptr<Optical_props_arry_rt>& optical_props,
                 Array_gpu<int,2>& jtemp, Array_gpu<int,2>& jpress,
-                Array_gpu<int,4>& jeta,
+                Array_gpu<int,3>& jeta,
                 Array_gpu<Bool,2>& tropo,
-                Array_gpu<Float,6>& fmajor,
+                Array_gpu<Float,5>& fmajor,
                 const Array_gpu<Float,2>& col_dry);
 
         void combine_abs_and_rayleigh(
@@ -316,8 +316,8 @@ class Gas_optics_rrtmgp_rt : public Gas_optics_rt
                 const Array_gpu<Float,2>& play, const Array_gpu<Float,2>& plev,
                 const Array_gpu<Float,2>& tlay, const Array_gpu<Float,1>& tsfc,
                 const Array_gpu<int,2>& jtemp, const Array_gpu<int,2>& jpress,
-                const Array_gpu<int,4>& jeta, const Array_gpu<Bool,2>& tropo,
-                const Array_gpu<Float,6>& fmajor,
+                const Array_gpu<int,3>& jeta, const Array_gpu<Bool,2>& tropo,
+                const Array_gpu<Float,5>& fmajor,
                 Source_func_lw_rt& sources,
                 const Array_gpu<Float,2>& tlev);
 };

--- a/include_rt/Gas_optics_rrtmgp_rt.h
+++ b/include_rt/Gas_optics_rrtmgp_rt.h
@@ -249,14 +249,12 @@ class Gas_optics_rrtmgp_rt : public Gas_optics_rt
         Array_gpu<int,2> jtemp;
         Array_gpu<int,2> jpress;;
         Array_gpu<Bool,2> tropo;
-        Array_gpu<Float,6> fmajor;
-        Array_gpu<int,4> jeta;
+        Array_gpu<Float,5> fmajor;
+        Array_gpu<int,3> jeta;
         Array_gpu<Float,3> vmr;
         Array_gpu<Float,3> col_gas;
-        Array_gpu<Float,4> col_mix;
-        Array_gpu<Float,5> fminor;
-        Array_gpu<Float,3> scalings_lower;
-        Array_gpu<Float,3> scalings_upper;
+        Array_gpu<Float,3> col_mix;
+        Array_gpu<Float,4> fminor;
 
         int get_ngas() const { return this->gas_names.dim(1); }
 

--- a/include_rt/Gas_optics_rt.h
+++ b/include_rt/Gas_optics_rt.h
@@ -57,7 +57,7 @@ class Gas_optics_rt : public Optical_props_rt
 
         // Longwave variant.
         virtual void gas_optics(
-                const int igpt,
+                const int igpt, const int col_s, const int ncol_block, const int ncol,
                 const Array_gpu<Float,2>& play,
                 const Array_gpu<Float,2>& plev,
                 const Array_gpu<Float,2>& tlay,
@@ -70,7 +70,7 @@ class Gas_optics_rt : public Optical_props_rt
 
         // Shortwave variant.
         virtual void gas_optics(
-                const int igpt,
+                const int igpt, const int col_s, const int ncol_block, const int ncol,
                 const Array_gpu<Float,2>& play,
                 const Array_gpu<Float,2>& plev,
                 const Array_gpu<Float,2>& tlay,

--- a/include_rt_kernels/gas_optics_rrtmgp_kernels_cuda_rt.h
+++ b/include_rt_kernels/gas_optics_rrtmgp_kernels_cuda_rt.h
@@ -46,6 +46,7 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
     void interpolation(
             const int ncol, const int nlay, const int igpt,
             const int ngas, const int nflav, const int neta, const int npres, const int ntemp,
+            const int* gpoint_flavor,
             const int* flavor,
             const Float* press_ref_log,
             const Float* temp_ref,
@@ -111,12 +112,10 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
             const Float* fminor, const Float* play,
             const Float* tlay, const Float* col_gas,
             const int* jeta, const int* jtemp,
-            const int* jpress, 
-            const Float* scalings_lower,
-            const Float* scalings_upper,
+            const int* jpress,
             Float* tau);
 
-    
+
     void Planck_source(
             const int ncol, const int nlay, const int nbnd, const int ngpt, const int igpt,
             const int nflav, const int neta, const int npres, const int ntemp,

--- a/include_rt_kernels/gas_optics_rrtmgp_kernels_cuda_rt.h
+++ b/include_rt_kernels/gas_optics_rrtmgp_kernels_cuda_rt.h
@@ -44,7 +44,7 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
 
 
     void interpolation(
-            const int ncol, const int nlay,
+            const int ncol, const int nlay, const int igpt,
             const int ngas, const int nflav, const int neta, const int npres, const int ntemp,
             const int* flavor,
             const Float* press_ref_log,
@@ -64,40 +64,15 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
             int* jeta,
             int* jpress);
 
-    
-    void minor_scalings(
-            const int ncol, const int nlay, const int nflav, const int ngpt, 
-            const int nminorlower, const int nminorupper,
-            const int idx_h2o,  
-            const int* gpoint_flavor,
-            const int* minor_limits_gpt_lower,
-            const int* minor_limits_gpt_upper,
-            const Bool* minor_scales_with_density_lower,
-            const Bool* minor_scales_with_density_upper,
-            const Bool* scale_by_complement_lower,
-            const Bool* scale_by_complement_upper,
-            const int* idx_minor_lower,
-            const int* idx_minor_upper,
-            const int* idx_minor_scaling_lower,
-            const int* idx_minor_scaling_upper,
-            const Float* play,
-            const Float* tlay,
-            const Float* col_gas,
-            const Bool* tropo,
-            Float* scalings_lower,
-            Float* scalings_upper);
-    
-    
     void combine_abs_and_rayleigh(
             const int ncol, const int nlay,
             const Float* tau_local, const Float* tau_rayleigh,
             Float* tau, Float* ssa, Float* g);
 
-    
+
     void compute_tau_rayleigh(
             const int ncol, const int nlay, const int nband, const int ngpt, const int igpt,
             const int ngas, const int nflav, const int neta, const int npres, const int ntemp,
-            const int* gpoint_flavor,
             const int* gpoint_bands,
             const int* band_lims_gpt,
             const Float* krayl,
@@ -106,14 +81,13 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
             const Bool* tropo, const int* jtemp,
             Float* tau_rayleigh);
 
-    
+
     void compute_tau_absorption(
             const int ncol, const int nlay, const int nband, const int ngpt, const int igpt,
             const int ngas, const int nflav, const int neta, const int npres, const int ntemp,
             const int nminorlower, const int nminorklower,
             const int nminorupper, const int nminorkupper,
             const int idx_h2o,
-            const int* gpoint_flavor,
             const int* band_lims_gpt,
             const Float* kmajor,
             const Float* kminor_lower,
@@ -161,7 +135,6 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
             const Float* pfracin,
             const Float temp_ref_min, const Float totplnk_delta,
             const Float* totplnk,
-            const int* gpoint_flavor,
             Float* sfc_src,
             Float* lay_src,
             Float* lev_src_inc,

--- a/include_rt_kernels/gas_optics_rrtmgp_kernels_cuda_rt.h
+++ b/include_rt_kernels/gas_optics_rrtmgp_kernels_cuda_rt.h
@@ -44,7 +44,7 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
 
 
     void interpolation(
-            const int ncol, const int nlay, const int igpt,
+            const int col_s, const int ncol_sub, const int ncol, const int nlay, const int igpt,
             const int ngas, const int nflav, const int neta, const int npres, const int ntemp,
             const int* gpoint_flavor,
             const int* flavor,
@@ -66,13 +66,13 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
             int* jpress);
 
     void combine_abs_and_rayleigh(
-            const int ncol, const int nlay,
+            const int col_s, const int ncol_sub, const int ncol, const int nlay,
             const Float* tau_local, const Float* tau_rayleigh,
             Float* tau, Float* ssa, Float* g);
 
 
     void compute_tau_rayleigh(
-            const int ncol, const int nlay, const int nband, const int ngpt, const int igpt,
+            const int col_s, const int ncol_sub, const int ncol, const int nlay, const int nband, const int ngpt, const int igpt,
             const int ngas, const int nflav, const int neta, const int npres, const int ntemp,
             const int* gpoint_bands,
             const int* band_lims_gpt,
@@ -84,7 +84,8 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
 
 
     void compute_tau_absorption(
-            const int ncol, const int nlay, const int nband, const int ngpt, const int igpt,
+            const int col_s, const int ncol_sub, const int ncol, const int nlay, const int nband, 
+            const int ngpt, const int igpt,
             const int ngas, const int nflav, const int neta, const int npres, const int ntemp,
             const int nminorlower, const int nminorklower,
             const int nminorupper, const int nminorkupper,

--- a/src_cuda_rt/Gas_optics_rrtmgp_rt.cu
+++ b/src_cuda_rt/Gas_optics_rrtmgp_rt.cu
@@ -1081,7 +1081,7 @@ void Gas_optics_rrtmgp_rt::compute_gas_taus(
     const int gas_2 = flavor({2,flav_1});
     const int gas_3 = flavor({1,flav_2});
     const int gas_4 = flavor({2,flav_2});
-    printf("%d %d %d %d\n",gas_1,gas_2,gas_3,gas_4);
+    
     add_if_not_in_vector(gases, gas_1);
     add_if_not_in_vector(gases, gas_2);
     add_if_not_in_vector(gases, gas_3);
@@ -1118,18 +1118,13 @@ void Gas_optics_rrtmgp_rt::compute_gas_taus(
     }
 
     for (int i=0; i<gases.size(); ++i)
-    //for (int i=0; i<ngas; ++i)
     {
-        //printf("%d ",gases[i]);
         const int igas = gases[i];
         const Array_gpu<Float,2>& vmr_2d = igas > 0 ? gas_desc.get_vmr(this->gas_names({igas})) : gas_desc.get_vmr(this->gas_names({1}));
-        std::string xx = (igas > 0) ? this->gas_names({igas}) : this->gas_names({1});
-        std::cout<< xx << "  ";
         fill_gases_kernel<<<grid_gpu, block_gpu>>>(
             ncol, nlay, vmr_2d.dim(1), vmr_2d.dim(2), ngas, igas, vmr_2d.ptr(), col_gas.ptr(), col_dry.ptr());
     }
-    std::cout <<" \n";
-   // printf("\n");
+    
     Gas_optics_rrtmgp_kernels_cuda_rt::interpolation(
             ncol, nlay, igpt,
             ngas, nflav, neta, npres, ntemp,

--- a/src_cuda_rt/Gas_optics_rrtmgp_rt.cu
+++ b/src_cuda_rt/Gas_optics_rrtmgp_rt.cu
@@ -1055,8 +1055,8 @@ void Gas_optics_rrtmgp_rt::compute_gas_taus(
         this->col_gas.set_offsets({0, 0, -1});
         this->col_mix.set_dims({2, ncol, nlay, this->get_nflav()});
         this->fminor.set_dims({2, 2, ncol, nlay, this->get_nflav()});
-        this->scalings_lower.set_dims({ncol, nlay,  this->minor_scales_with_density_lower.dim(1)});
-        this->scalings_upper.set_dims({ncol, nlay,  this->minor_scales_with_density_upper.dim(1)});
+//        this->scalings_lower.set_dims({ncol, nlay,  this->minor_scales_with_density_lower.dim(1)});
+//        this->scalings_upper.set_dims({ncol, nlay,  this->minor_scales_with_density_upper.dim(1)});
     }
 
     const int block_lay = 16;
@@ -1106,28 +1106,28 @@ void Gas_optics_rrtmgp_rt::compute_gas_taus(
     if (this->idx_h2o == -1)
         throw std::runtime_error("idx_h2o cannot be found");
 
-    Gas_optics_rrtmgp_kernels_cuda_rt::minor_scalings(
-            ncol, nlay, nflav, ngpt,
-            nminorlower, nminorupper,
-            idx_h2o,
-            gpoint_flavor_gpu.ptr(),
-            minor_limits_gpt_lower_gpu.ptr(),
-            minor_limits_gpt_upper_gpu.ptr(),
-            minor_scales_with_density_lower_gpu.ptr(),
-            minor_scales_with_density_upper_gpu.ptr(),
-            scale_by_complement_lower_gpu.ptr(),
-            scale_by_complement_upper_gpu.ptr(),
-            idx_minor_lower_gpu.ptr(),
-            idx_minor_upper_gpu.ptr(),
-            idx_minor_scaling_lower_gpu.ptr(),
-            idx_minor_scaling_upper_gpu.ptr(),
-            play.ptr(),
-            tlay.ptr(),
-            col_gas.ptr(),
-            tropo.ptr(),
-            scalings_lower.ptr(),
-            scalings_upper.ptr());
-
+//    Gas_optics_rrtmgp_kernels_cuda_rt::minor_scalings(
+//            ncol, nlay, nflav, ngpt,
+//            nminorlower, nminorupper,
+//            idx_h2o,
+//            gpoint_flavor_gpu.ptr(),
+//            minor_limits_gpt_lower_gpu.ptr(),
+//            minor_limits_gpt_upper_gpu.ptr(),
+//            minor_scales_with_density_lower_gpu.ptr(),
+//            minor_scales_with_density_upper_gpu.ptr(),
+//            scale_by_complement_lower_gpu.ptr(),
+//            scale_by_complement_upper_gpu.ptr(),
+//            idx_minor_lower_gpu.ptr(),
+//            idx_minor_upper_gpu.ptr(),
+//            idx_minor_scaling_lower_gpu.ptr(),
+//            idx_minor_scaling_upper_gpu.ptr(),
+//            play.ptr(),
+//            tlay.ptr(),
+//            col_gas.ptr(),
+//            tropo.ptr(),
+//            scalings_lower.ptr(),
+//            scalings_upper.ptr());
+//
 
     bool has_rayleigh = (this->krayl.size() > 0);
 

--- a/src_kernels_cuda_rt/gas_optics_rrtmgp_kernels_launchers_rt.cu
+++ b/src_kernels_cuda_rt/gas_optics_rrtmgp_kernels_launchers_rt.cu
@@ -139,6 +139,7 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
     void interpolation(
             const int ncol, const int nlay, const int igpt,
             const int ngas, const int nflav, const int neta, const int npres, const int ntemp,
+            const int* gpoint_flavor,
             const int* flavor,
             const Float* press_ref_log,
             const Float* temp_ref,
@@ -169,7 +170,7 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
                     {1, 2, 4, 8, 16, 32, 64, 128, 256, 512}, {1, 2, 4}, {1},
                     interpolation_kernel,
                     igpt, ncol, nlay, ngas, nflav, neta, npres, ntemp, tmin,
-                    flavor, press_ref_log, temp_ref,
+                    gpoint_flavor, flavor, press_ref_log, temp_ref,
                     press_ref_log_delta, temp_ref_min,
                     temp_ref_delta, press_ref_trop_log,
                     vmr_ref, play, tlay,
@@ -188,7 +189,7 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
 
         interpolation_kernel<<<grid, block>>>(
                 igpt, ncol, nlay, ngas, nflav, neta, npres, ntemp, tmin,
-                flavor, press_ref_log, temp_ref,
+                gpoint_flavor, flavor, press_ref_log, temp_ref,
                 press_ref_log_delta, temp_ref_min,
                 temp_ref_delta, press_ref_trop_log,
                 vmr_ref, play, tlay,
@@ -324,8 +325,6 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
             const Float* tlay, const Float* col_gas,
             const int* jeta, const int* jtemp,
             const int* jpress,
-            const Float* scalings_lower,
-            const Float* scalings_upper,
             Float* tau)
     {
         Tuner_map& tunings = Tuner::get_map();
@@ -402,7 +401,7 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
                         kminor_start_lower,
                         play, tlay, col_gas,
                         fminor, jeta, jtemp,
-                        tropo, scalings_lower,
+                        tropo,
                         tau_tmp);
             Tools_gpu::free_gpu<Float>(tau_tmp);
 
@@ -433,7 +432,7 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
                 kminor_start_lower,
                 play, tlay, col_gas,
                 fminor, jeta, jtemp,
-                tropo, scalings_lower, tau);
+                tropo, tau);
 
         // Upper
         idx_tropo = 0;
@@ -463,7 +462,7 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
                    kminor_start_upper,
                    play, tlay, col_gas,
                    fminor, jeta, jtemp,
-                   tropo, scalings_upper,
+                   tropo,
                    tau_tmp);
             Tools_gpu::free_gpu<Float>(tau_tmp);
 
@@ -494,7 +493,7 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
                 kminor_start_upper,
                 play, tlay, col_gas,
                 fminor, jeta, jtemp,
-                tropo, scalings_upper, tau);
+                tropo, tau);
 
     }
 

--- a/src_kernels_cuda_rt/gas_optics_rrtmgp_kernels_launchers_rt.cu
+++ b/src_kernels_cuda_rt/gas_optics_rrtmgp_kernels_launchers_rt.cu
@@ -11,6 +11,8 @@
 namespace
 {
     #include "gas_optics_rrtmgp_kernels_rt.cu"
+
+    using Tools_gpu::calc_grid_size;
 }
 
 
@@ -41,9 +43,10 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
         }
         else
         {
-            grid = tunings["reorder123x321_kernel_rt"].first;
             block = tunings["reorder123x321_kernel_rt"].second;
         }
+
+        grid = calc_grid_size(block, dim3(ni, nj, nk));
 
         reorder123x321_kernel<<<grid, block>>>(
                 ni, nj, nk, arr_in, arr_out);
@@ -178,9 +181,10 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
         }
         else
         {
-            grid = tunings["interpolation_kernel_rt"].first;
             block = tunings["interpolation_kernel_rt"].second;
         }
+         
+        grid = calc_grid_size(block, dim3(ncol, nlay, nflav));
 
         interpolation_kernel<<<grid, block>>>(
                 ncol, nlay, ngas, nflav, neta, npres, ntemp, tmin,
@@ -246,9 +250,10 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
         }
         else
         {
-            grid_1 =  tunings["minor_scalings_lower_kernel_rt"].first;
             block_1 = tunings["minor_scalings_lower_kernel_rt"].second;
         }
+        
+        grid_1 = calc_grid_size(block_1, dim3(ncol, nlay, nminorlower));
 
         scaling_kernel<<<grid_1, block_1>>>(
                 ncol, nlay, nflav, nminorlower,
@@ -289,10 +294,11 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
         }
         else
         {
-            grid_2 =  tunings["minor_scalings_upper_kernel_rt"].first;
             block_2 = tunings["minor_scalings_upper_kernel_rt"].second;
         }
 
+        grid_2 = calc_grid_size(block_2, dim3(ncol, nlay, nminorupper));
+        
         scaling_kernel<<<grid_2, block_2>>>(
                 ncol, nlay, nflav, nminorupper,
                 idx_h2o, idx_tropo,
@@ -335,9 +341,10 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
         }
         else
         {
-            grid = tunings["combine_abs_and_rayleigh_kernel_rt"].first;
             block = tunings["combine_abs_and_rayleigh_kernel_rt"].second;
         }
+
+        grid = calc_grid_size(block, dim3(ncol, nlay, 1));
 
         combine_abs_and_rayleigh_kernel<<<grid, block>>>(
                 ncol, nlay, tmin,
@@ -385,10 +392,11 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
         }
         else
         {
-            grid = tunings["compute_tau_rayleigh_kernel_rt"].first;
             block = tunings["compute_tau_rayleigh_kernel_rt"].second;
         }
 
+        grid = calc_grid_size(block, dim3(ncol, nlay, 1));
+       
         compute_tau_rayleigh_kernel<<<grid, block>>>(
                 ncol, nlay, nbnd, ngpt,
                 ngas, nflav, neta, npres, ntemp,
@@ -468,9 +476,10 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
         }
         else
         {
-            grid_maj = tunings["gas_optical_depths_major_kernel_rt"].first;
             block_maj = tunings["gas_optical_depths_major_kernel_rt"].second;
         }
+        
+        grid_maj = calc_grid_size(block_maj, dim3(ncol, nlay, 1));
 
         gas_optical_depths_major_kernel<<<grid_maj, block_maj>>>(
             ncol, nlay, nband, ngpt,
@@ -524,9 +533,10 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
         }
         else
         {
-            grid_min_1 = tunings["gas_optical_depths_minor_kernel_lower_rt"].first;
             block_min_1 = tunings["gas_optical_depths_minor_kernel_lower_rt"].second;
         }
+        
+        grid_min_1 = calc_grid_size(block_min_1, dim3(ncol, nlay, 1));
 
         gas_optical_depths_minor_kernel<<<grid_min_1, block_min_1>>>(
                 ncol, nlay, ngpt, igpt,
@@ -586,9 +596,10 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
         }
         else
         {
-            grid_min_2 = tunings["gas_optical_depths_minor_kernel_upper_rt"].first;
             block_min_2 = tunings["gas_optical_depths_minor_kernel_upper_rt"].second;
         }
+        
+        grid_min_2 = calc_grid_size(block_min_2, dim3(ncol, nlay, 1));
 
         gas_optical_depths_minor_kernel<<<grid_min_2, block_min_2>>>(
                 ncol, nlay, ngpt, igpt,
@@ -667,9 +678,10 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
         }
         else
         {
-            grid = tunings["Planck_source_kernel_rt"].first;
             block = tunings["Planck_source_kernel_rt"].second;
         }
+        
+        grid = calc_grid_size(block, dim3(ncol, nlay, 1));
 
         Planck_source_kernel<<<grid, block>>>(
                 ncol, nlay, nbnd, ngpt,

--- a/src_kernels_cuda_rt/gas_optics_rrtmgp_kernels_launchers_rt.cu
+++ b/src_kernels_cuda_rt/gas_optics_rrtmgp_kernels_launchers_rt.cu
@@ -232,7 +232,7 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
             std::tie(grid_1, block_1) = tune_kernel(
                     "minor_scalings_lower_kernel_rt",
                     dim3(ncol, nlay, nminorlower),
-                    {8, 16, 24, 32, 48, 64, 128}, {1}, {1, 2, 4, 8, 16, 32},
+                    {8, 16, 24, 32, 64, 128, 256, 512}, {1}, {1, 2, 4, 8, 16, 32},
                     scaling_kernel,
                     ncol, nlay, nflav, nminorlower,
                     idx_h2o, idx_tropo,
@@ -276,7 +276,7 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
             std::tie(grid_2, block_2) = tune_kernel(
                     "minor_scalings_upper_kernel_rt",
                     dim3(ncol, nlay, nminorupper),
-                    {8, 16, 24, 32, 48, 64, 128}, {1}, {1, 2, 4, 8, 16, 32},
+                    {8, 16, 24, 32, 48, 64, 128, 256,512}, {1}, {1, 2, 4, 8, 16, 32},
                     scaling_kernel,
                     ncol, nlay, nflav, nminorupper,
                     idx_h2o, idx_tropo,

--- a/src_kernels_cuda_rt/gas_optics_rrtmgp_kernels_launchers_rt.cu
+++ b/src_kernels_cuda_rt/gas_optics_rrtmgp_kernels_launchers_rt.cu
@@ -479,7 +479,7 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
             block_maj = tunings["gas_optical_depths_major_kernel_rt"].second;
         }
         
-        grid_maj = calc_grid_size(block_maj, dim3(ncol, nlay, 1));
+        grid_maj = calc_grid_size(block_maj, dim3(nlay, ncol, 1));
 
         gas_optical_depths_major_kernel<<<grid_maj, block_maj>>>(
             ncol, nlay, nband, ngpt,
@@ -536,7 +536,7 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
             block_min_1 = tunings["gas_optical_depths_minor_kernel_lower_rt"].second;
         }
         
-        grid_min_1 = calc_grid_size(block_min_1, dim3(ncol, nlay, 1));
+        grid_min_1 = calc_grid_size(block_min_1, dim3(nlay, ncol, 1));
 
         gas_optical_depths_minor_kernel<<<grid_min_1, block_min_1>>>(
                 ncol, nlay, ngpt, igpt,
@@ -599,7 +599,7 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
             block_min_2 = tunings["gas_optical_depths_minor_kernel_upper_rt"].second;
         }
         
-        grid_min_2 = calc_grid_size(block_min_2, dim3(ncol, nlay, 1));
+        grid_min_2 = calc_grid_size(block_min_2, dim3(nlay, ncol, 1));
 
         gas_optical_depths_minor_kernel<<<grid_min_2, block_min_2>>>(
                 ncol, nlay, ngpt, igpt,

--- a/src_kernels_cuda_rt/gas_optics_rrtmgp_kernels_launchers_rt.cu
+++ b/src_kernels_cuda_rt/gas_optics_rrtmgp_kernels_launchers_rt.cu
@@ -161,13 +161,13 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
         Tuner_map& tunings = Tuner::get_map();
         Float tmin = std::numeric_limits<Float>::min();
 
-        dim3 grid(ncol, nlay, 1), block;
+        dim3 grid(nlay, ncol, 1), block;
         if (tunings.count("interpolation_kernel_rt") == 0)
         {
             std::tie(grid, block) = tune_kernel(
                     "interpolation_kernel_rt",
-                    dim3(ncol, nlay, 1),
-                    {1, 2, 4, 8, 16, 32, 64, 128, 256, 512}, {1, 2, 4}, {1},
+                    dim3(nlay, ncol, 1),
+                    {1,2,4}, {1, 2, 4, 8, 16, 32, 64, 128, 256, 512}, {1},
                     interpolation_kernel,
                     igpt, ncol, nlay, ngas, nflav, neta, npres, ntemp, tmin,
                     gpoint_flavor, flavor, press_ref_log, temp_ref,
@@ -185,7 +185,7 @@ namespace Gas_optics_rrtmgp_kernels_cuda_rt
             block = tunings["interpolation_kernel_rt"].second;
         }
 
-        grid = calc_grid_size(block, dim3(ncol, nlay, 1));
+        grid = calc_grid_size(block, dim3(nlay, ncol, 1));
 
         interpolation_kernel<<<grid, block>>>(
                 igpt, ncol, nlay, ngas, nflav, neta, npres, ntemp, tmin,

--- a/src_kernels_cuda_rt/gas_optics_rrtmgp_kernels_rt.cu
+++ b/src_kernels_cuda_rt/gas_optics_rrtmgp_kernels_rt.cu
@@ -184,7 +184,7 @@ void Planck_source_kernel(
         const int* __restrict__ jpress, const int* __restrict__ gpoint_bands,
         const int* __restrict__ band_lims_gpt, const Float* __restrict__ pfracin,
         const Float temp_ref_min, const Float totplnk_delta,
-        const Float* __restrict__ totplnk, const int* __restrict__ gpoint_flavor,
+        const Float* __restrict__ totplnk,
         const Float delta_Tsurf,
         Float* __restrict__ sfc_src, Float* __restrict__ lay_src,
         Float* __restrict__ lev_src_inc, Float* __restrict__ lev_src_dec,
@@ -200,10 +200,8 @@ void Planck_source_kernel(
         const int itropo = !tropo[idx_collay];
         const int gpt_start = band_lims_gpt[2*ibnd] - 1;
 
-        const int iflav = gpoint_flavor[itropo + 2*gpt_start] - 1;
-
-        const int idx_fcl3 = 2 * 2 * 2 * (icol + ilay*ncol + iflav*ncol*nlay);
-        const int idx_fcl1 = 2 *         (icol + ilay*ncol + iflav*ncol*nlay);
+        const int idx_fcl3 = 2 * 2 * 2 * (icol + ilay*ncol);
+        const int idx_fcl1 = 2 *         (icol + ilay*ncol);
 
         const int j0 = jeta[idx_fcl1+0];
         const int j1 = jeta[idx_fcl1+1];
@@ -258,6 +256,7 @@ void Planck_source_kernel(
 
 __global__
 void interpolation_kernel(
+        const int igpt,
         const int ncol, const int nlay, const int ngas, const int nflav,
         const int neta, const int npres, const int ntemp, const Float tmin,
         const int* __restrict__ flavor,
@@ -280,53 +279,56 @@ void interpolation_kernel(
 {
     const int icol  = blockIdx.x*blockDim.x + threadIdx.x;
     const int ilay  = blockIdx.y*blockDim.y + threadIdx.y;
-    const int iflav = blockIdx.z*blockDim.z + threadIdx.z;
 
-    if ( (icol < ncol) && (ilay < nlay) && (iflav < nflav) )
+    if ( (icol < ncol) && (ilay < nlay) )
     {
         const int idx = icol + ilay*ncol;
 
+        const int itropo = !tropo[idx];
+        const int iflav = flavor[itropo + 2*igpt] - 1;
+
+        const Float locpress = Float(1.) + (log(play[idx]) - press_ref_log[0]) / press_ref_log_delta;
+
         jtemp[idx] = int((tlay[idx] - (temp_ref_min-temp_ref_delta)) / temp_ref_delta);
         jtemp[idx] = min(ntemp-1, max(1, jtemp[idx]));
-        const Float ftemp = (tlay[idx] - temp_ref[jtemp[idx]-1]) / temp_ref_delta;
-        const Float locpress = Float(1.) + (log(play[idx]) - press_ref_log[0]) / press_ref_log_delta;
+
         jpress[idx] = min(npres-1, max(1, int(locpress)));
+        tropo[idx] = log(play[idx]) > press_ref_trop_log;
+
+
+        const Float ftemp = (tlay[idx] - temp_ref[jtemp[idx]-1]) / temp_ref_delta;
         const Float fpress = locpress - Float(jpress[idx]);
 
-        tropo[idx] = log(play[idx]) > press_ref_trop_log;
-        const int itropo = !tropo[idx];
+        const int gas_idx1 = flavor[2*iflav  ];
+        const int gas_idx2 = flavor[2*iflav+1];
 
-        const int gas1 = flavor[2*iflav  ];
-        const int gas2 = flavor[2*iflav+1];
+        const Float gas1 = col_gas[idx + gas_idx1*nlay*ncol];
+        const Float gas2 = col_gas[idx + gas_idx2*nlay*ncol];
 
         for (int itemp=0; itemp<2; ++itemp)
         {
             const int vmr_base_idx = itropo + (jtemp[idx]+itemp-1) * (ngas+1) * 2;
-            const int colmix_idx = itemp + 2*(icol + ilay*ncol + iflav*ncol*nlay);
-            const int colgas1_idx = icol + ilay*ncol + gas1*nlay*ncol;
-            const int colgas2_idx = icol + ilay*ncol + gas2*nlay*ncol;
-            const Float ratio_eta_half = vmr_ref[vmr_base_idx + 2*gas1] /
-                                      vmr_ref[vmr_base_idx + 2*gas2];
-            col_mix[colmix_idx] = col_gas[colgas1_idx] + ratio_eta_half * col_gas[colgas2_idx];
+            const int col_mix_idx = itemp + 2*idx;
+            const Float ratio_eta_half = vmr_ref[vmr_base_idx + 2*gas_idx1] /
+                                         vmr_ref[vmr_base_idx + 2*gas_idx2];
 
-            Float eta;
-            if (col_mix[colmix_idx] > Float(2.)*tmin)
-                eta = col_gas[colgas1_idx] / col_mix[colmix_idx];
-            else
-                eta = Float(0.5);
+            const Float col_gasmix =  gas1 + ratio_eta_half * gas2;
+            col_mix[col_mix_idx] = col_gasmix;
+
+            const Float eta = (col_gasmix > Float(2.)*tmin) ? gas1 / col_gasmix : Float(0.5);
 
             const Float loceta = eta * Float(neta-1);
-            jeta[colmix_idx] = min(int(loceta)+1, neta-1);
+            jeta[col_mix_idx] = min(int(loceta)+1, neta-1);
             const Float feta = fmod(loceta, Float(1.));
             const Float ftemp_term = Float(1-itemp) + Float(2*itemp-1)*ftemp;
 
             // Compute interpolation fractions needed for minor species.
-            const int fminor_idx = 2*(itemp + 2*(icol + ilay*ncol + iflav*ncol*nlay));
+            const int fminor_idx = 2*(itemp + 2*idx);
             fminor[fminor_idx  ] = (Float(1.)-feta) * ftemp_term;
             fminor[fminor_idx+1] = feta * ftemp_term;
 
             // Compute interpolation fractions needed for major species.
-            const int fmajor_idx = 2*2*(itemp + 2*(icol + ilay*ncol + iflav*ncol*nlay));
+            const int fmajor_idx = 2*2*(itemp + 2*idx);
             fmajor[fmajor_idx  ] = (Float(1.)-fpress) * fminor[fminor_idx  ];
             fmajor[fmajor_idx+1] = (Float(1.)-fpress) * fminor[fminor_idx+1];
             fmajor[fmajor_idx+2] = fpress * fminor[fminor_idx  ];
@@ -340,7 +342,6 @@ void gas_optical_depths_major_kernel(
         const int ncol, const int nlay, const int nband, const int ngpt,
         const int nflav, const int neta, const int npres, const int ntemp,
         const int igpt,
-        const int* __restrict__ gpoint_flavor,
         const int* __restrict__ band_lims_gpt,
         const Float* __restrict__ kmajor,
         const Float* __restrict__ col_mix, const Float* __restrict__ fmajor,
@@ -355,15 +356,14 @@ void gas_optical_depths_major_kernel(
     {
         const int idx_collay = icol + ilay*ncol;
         const int itropo = !tropo[idx_collay];
-        const int iflav = gpoint_flavor[itropo + 2*igpt] - 1;
 
         const int ljtemp = jtemp[idx_collay];
         const int jpressi = jpress[idx_collay] + itropo;
         const int npress = npres+1;
 
         // Major gases.
-        const int idx_fcl3 = 2 * 2 * 2 * (icol + ilay*ncol + iflav*ncol*nlay);
-        const int idx_fcl1 = 2 *         (icol + ilay*ncol + iflav*ncol*nlay);
+        const int idx_fcl3 = 2 * 2 * 2 * (icol + ilay*ncol);
+        const int idx_fcl1 = 2 *         (icol + ilay*ncol);
 
         const Float* __restrict__ ifmajor = &fmajor[idx_fcl3];
 
@@ -383,60 +383,6 @@ void gas_optical_depths_major_kernel(
 }
 
 __global__
-void scaling_kernel(
-        const int ncol, const int nlay, const int nflav, const int nminor,
-        const int idx_h2o, const int idx_tropo,
-        const int* __restrict__ gpoint_flavor,
-        const int* __restrict__ minor_limits_gpt,
-        const Bool* __restrict__ minor_scales_with_density,
-        const Bool* __restrict__ scale_by_complement,
-        const int* __restrict__ idx_minor,
-        const int* __restrict__ idx_minor_scaling,
-        const Float* __restrict__ play,
-        const Float* __restrict__ tlay,
-        const Float* __restrict__ col_gas,
-        const Bool* __restrict__ tropo,
-        Float* __restrict__ scalings)
-{
-    const int icol = blockIdx.x * blockDim.x + threadIdx.x;
-    const int ilay = blockIdx.y * blockDim.y + threadIdx.y;
-    const int imnr = blockIdx.z * blockDim.z + threadIdx.z;
-
-    if ( (icol < ncol) && (ilay < nlay) && (imnr < nminor) )
-    {
-        const int idx_collay = icol + ilay*ncol;
-        if ((tropo[idx_collay] == idx_tropo) )
-        {
-            // const int gpt_offs = 1-idx_tropo;
-
-            const int idx_out = icol + ilay*ncol + imnr*ncol*nlay;
-            const int ncl = ncol * nlay;
-
-            Float scaling = col_gas[idx_collay + idx_minor[imnr] * ncl];
-
-            if (minor_scales_with_density[imnr])
-            {
-                const Float PaTohPa = 0.01;
-                scaling *= PaTohPa * play[idx_collay] / tlay[idx_collay];
-
-                if (idx_minor_scaling[imnr] > 0)
-                {
-                    const int idx_collaywv = icol + ilay*ncol + idx_h2o*ncl;
-                    Float vmr_fact = Float(1.) / col_gas[idx_collay];
-                    Float dry_fact = Float(1.) / (Float(1.) + col_gas[idx_collaywv] * vmr_fact);
-
-                    if (scale_by_complement[imnr])
-                        scaling *= (Float(1.) - col_gas[idx_collay + idx_minor_scaling[imnr] * ncl] * vmr_fact * dry_fact);
-                    else
-                        scaling *= col_gas[idx_collay + idx_minor_scaling[imnr] * ncl] * vmr_fact * dry_fact;
-                }
-            }
-            scalings[idx_out] = scaling;
-        }
-    }
-}
-
-__global__
 void gas_optical_depths_minor_kernel(
         const int ncol, const int nlay, const int ngpt, const int igpt,
         const int ngas, const int nflav, const int ntemp, const int neta,
@@ -444,7 +390,6 @@ void gas_optical_depths_minor_kernel(
         const int nminor,
         const int nminork,
         const int idx_h2o, const int idx_tropo,
-        const int* __restrict__ gpoint_flavor,
         const Float* __restrict__ kminor,
         const int* __restrict__ minor_limits_gpt,
         const int* __restrict__ first_last_minor,
@@ -468,7 +413,7 @@ void gas_optical_depths_minor_kernel(
 
     if ( (icol < ncol) && (ilay < nlay) )
     {
-        const int ncollay = ncol * nlay; 
+        const int ncollay = ncol * nlay;
         const int idx_collay = icol + ilay*ncol;
         const int minor_start = first_last_minor[2*igpt];
         const int minor_end   = first_last_minor[2*igpt+1];
@@ -477,10 +422,9 @@ void gas_optical_depths_minor_kernel(
         {
 
             const int gpt_offs = 1-idx_tropo;
-            const int iflav = gpoint_flavor[2*igpt + gpt_offs]-1;
 
-            const int idx_fcl2 = 2 * 2 * (idx_collay + iflav*ncollay);
-            const int idx_fcl1 = 2 * (idx_collay + iflav*ncollay);
+            const int idx_fcl2 = 2 * 2 * idx_collay;
+            const int idx_fcl1 = 2 * idx_collay;
 
             const Float* kfminor = &fminor[idx_fcl2];
             const Float* kin = &kminor[0];
@@ -488,23 +432,22 @@ void gas_optical_depths_minor_kernel(
             const int j0 = jeta[idx_fcl1];
             const int j1 = jeta[idx_fcl1+1];
             const int kjtemp = jtemp[idx_collay];
-            
+
             for (int imnr=minor_start; imnr<=minor_end; ++imnr)
             {
-                const int idx_scl = icol + ilay*ncol + imnr*ncol*nlay;
-                Float scaling = col_gas[idx_collay + idx_minor[imnr] * ncollay]; //mv
-                
+                Float scaling = col_gas[idx_collay + idx_minor[imnr] * ncollay];
+
                 if (minor_scales_with_density[imnr])
                 {
                     const Float PaTohPa = Float(0.01);
                     scaling *= PaTohPa * play[idx_collay] / tlay[idx_collay];
-                
+
                     if (idx_minor_scaling[imnr] > 0)
                     {
-                        const int idx_collaywv = idx_collay + idx_h2o*ncollay;     
+                        const int idx_collaywv = idx_collay + idx_h2o*ncollay;
                         const Float vmr_fact = Float(1.) / col_gas[idx_collay];
                         const Float dry_fact = Float(1.) / (Float(1.) + col_gas[idx_collaywv] * vmr_fact);
-                        
+
                         if (scale_by_complement[imnr])
                             scaling *= (Float(1.) - col_gas[idx_collay + idx_minor_scaling[imnr] * ncollay] * vmr_fact * dry_fact);
                         else
@@ -520,7 +463,7 @@ void gas_optical_depths_minor_kernel(
                                    kfminor[2] * kin[kjtemp     + (j1-1)*ntemp + (igpt-start_of_band+gpt_offset)*ntemp*neta] +
                                    kfminor[3] * kin[kjtemp     +  j1   *ntemp + (igpt-start_of_band+gpt_offset)*ntemp*neta];
 
-                tau[idx_collay] += ltau_minor * scaling;//s[idx_scl];
+                tau[idx_collay] += ltau_minor * scaling;
             }
         }
     }
@@ -531,7 +474,6 @@ void compute_tau_rayleigh_kernel(
         const int ncol, const int nlay, const int nbnd, const int ngpt,
         const int ngas, const int nflav, const int neta, const int npres, const int ntemp,
         const int igpt,
-        const int* __restrict__ gpoint_flavor,
         const int* __restrict__ gpoint_bands,
         const int* __restrict__ band_lims_gpt,
         const Float* __restrict__ krayl,
@@ -553,10 +495,9 @@ void compute_tau_rayleigh_kernel(
         const int itropo = !tropo[idx_collay];
 
         const int gpt_start = band_lims_gpt[2*ibnd]-1;
-        const int iflav = gpoint_flavor[itropo+2*gpt_start]-1;
 
-        const int idx_fcl2 = 2*2*(icol + ilay*ncol + iflav*ncol*nlay);
-        const int idx_fcl1 =   2*(icol + ilay*ncol + iflav*ncol*nlay);
+        const int idx_fcl2 = 2*2*(icol + ilay*ncol);
+        const int idx_fcl1 =   2*(icol + ilay*ncol);
 
         const int idx_krayl = itropo*ntemp*neta*ngpt;
 

--- a/src_kernels_cuda_rt/gas_optics_rrtmgp_kernels_rt.cu
+++ b/src_kernels_cuda_rt/gas_optics_rrtmgp_kernels_rt.cu
@@ -259,6 +259,7 @@ void interpolation_kernel(
         const int igpt,
         const int ncol, const int nlay, const int ngas, const int nflav,
         const int neta, const int npres, const int ntemp, const Float tmin,
+        const int* __restrict__ gpoint_flavor,
         const int* __restrict__ flavor,
         const Float* __restrict__ press_ref_log,
         const Float* __restrict__ temp_ref,
@@ -285,7 +286,7 @@ void interpolation_kernel(
         const int idx = icol + ilay*ncol;
 
         const int itropo = !tropo[idx];
-        const int iflav = flavor[itropo + 2*igpt] - 1;
+        const int iflav = gpoint_flavor[itropo + 2*igpt] - 1;
 
         const Float locpress = Float(1.) + (log(play[idx]) - press_ref_log[0]) / press_ref_log_delta;
 
@@ -405,7 +406,6 @@ void gas_optical_depths_minor_kernel(
         const int* __restrict__ jeta,
         const int* __restrict__ jtemp,
         const Bool* __restrict__ tropo,
-        const Float* __restrict__ scalings,
         Float* __restrict__ tau)
 {
     const int ilay = blockIdx.x * blockDim.x + threadIdx.x;

--- a/src_kernels_cuda_rt/gas_optics_rrtmgp_kernels_rt.cu
+++ b/src_kernels_cuda_rt/gas_optics_rrtmgp_kernels_rt.cu
@@ -198,7 +198,6 @@ void Planck_source_kernel(
         const int ibnd = gpoint_bands[igpt]-1;
         const int idx_collay = icol + ilay * ncol;
         const int itropo = !tropo[idx_collay];
-        const int gpt_start = band_lims_gpt[2*ibnd] - 1;
 
         const int idx_fcl3 = 2 * 2 * 2 * (icol + ilay*ncol);
         const int idx_fcl1 = 2 *         (icol + ilay*ncol);
@@ -278,8 +277,8 @@ void interpolation_kernel(
         int* __restrict__ jeta,
         int* __restrict__ jpress)
 {
-    const int icol  = blockIdx.x*blockDim.x + threadIdx.x;
-    const int ilay  = blockIdx.y*blockDim.y + threadIdx.y;
+    const int icol  = blockIdx.y*blockDim.y + threadIdx.y;
+    const int ilay  = blockIdx.x*blockDim.x + threadIdx.x;
 
     if ( (icol < ncol) && (ilay < nlay) )
     {
@@ -420,9 +419,6 @@ void gas_optical_depths_minor_kernel(
 
         if ((tropo[idx_collay] == idx_tropo) && (minor_start >= 0) )
         {
-
-            const int gpt_offs = 1-idx_tropo;
-
             const int idx_fcl2 = 2 * 2 * idx_collay;
             const int idx_fcl1 = 2 * idx_collay;
 
@@ -488,13 +484,9 @@ void compute_tau_rayleigh_kernel(
 
     if ( (icol < ncol) && (ilay < nlay) )
     {
-        const int ibnd = gpoint_bands[igpt]-1;
-
         const int idx_collay = icol + ilay*ncol;
         const int idx_collaywv = icol + ilay*ncol + idx_h2o*nlay*ncol;
         const int itropo = !tropo[idx_collay];
-
-        const int gpt_start = band_lims_gpt[2*ibnd]-1;
 
         const int idx_fcl2 = 2*2*(icol + ilay*ncol);
         const int idx_fcl1 =   2*(icol + ilay*ncol);

--- a/src_kernels_cuda_rt/rte_solver_kernels_launchers_rt.cu
+++ b/src_kernels_cuda_rt/rte_solver_kernels_launchers_rt.cu
@@ -11,6 +11,8 @@
 namespace
 {
     #include "rte_solver_kernels_rt.cu"
+    
+    using Tools_gpu::calc_grid_size;
 }
 
 
@@ -120,9 +122,10 @@ namespace Rte_solver_kernels_cuda_rt
         }
         else
         {
-            grid_1 = tunings["lw_step_1_rt"].first;
             block_1 = tunings["lw_step_1_rt"].second;
         }
+
+        grid_1 = calc_grid_size(block_1, dim3(ncol, nlay, 1));
 
         lw_solver_noscat_step_1_kernel<<<grid_1, block_1>>>(
                 ncol, nlay, ngpt, eps, top_at_1, ds, weights, tau, lay_source,
@@ -157,9 +160,10 @@ namespace Rte_solver_kernels_cuda_rt
         }
         else
         {
-            grid_2 = tunings["lw_step_2_rt"].first;
             block_2 = tunings["lw_step_2_rt"].second;
         }
+        
+        grid_2 = calc_grid_size(block_2, dim3(ncol, 1, 1));
 
         lw_solver_noscat_step_2_kernel<<<grid_2, block_2>>>(
                 ncol, nlay, ngpt, eps, top_at_1, ds, weights, tau, lay_source,
@@ -194,9 +198,10 @@ namespace Rte_solver_kernels_cuda_rt
         }
         else
         {
-            grid_3 = tunings["lw_step_3_rt"].first;
             block_3 = tunings["lw_step_3_rt"].second;
         }
+        
+        grid_3 = calc_grid_size(block_3, dim3(ncol, nlay+1, 1));
 
         lw_solver_noscat_step_3_kernel<<<grid_3, block_3>>>(
                 ncol, nlay, ngpt, eps, top_at_1, ds, weights, tau, lay_source,
@@ -302,10 +307,11 @@ namespace Rte_solver_kernels_cuda_rt
         }
         else
         {
-            grid_source = tunings["sw_source_2stream_kernel_rt"].first;
             block_source = tunings["sw_source_2stream_kernel_rt"].second;
         }
-
+            
+        grid_source = calc_grid_size(block_source, dim3(ncol, 1));
+        
         if (top_at_1)
         {
             sw_source_2stream_kernel<1><<<grid_source, block_source>>>(
@@ -362,9 +368,10 @@ namespace Rte_solver_kernels_cuda_rt
         }
         else
         {
-            grid_adding = tunings["sw_adding_rt"].first;
             block_adding = tunings["sw_adding_rt"].second;
         }
+        
+        grid_adding = calc_grid_size(block_adding, dim3(ncol, 1));
 
         if (top_at_1)
         {

--- a/src_test/Radiation_solver_rt.cu
+++ b/src_test/Radiation_solver_rt.cu
@@ -701,7 +701,7 @@ void Radiation_solver_shortwave::solve_gpu(
         }
 
         // We loop over the gas optics, due to memory constraints
-        constexpr int n_col_block = 1<<14; // 2^14
+        constexpr int n_col_block = 1<<17;
 
         Array_gpu<Float,1> toa_src_temp({n_col_block});
 

--- a/src_test/Radiation_solver_rt.cu
+++ b/src_test/Radiation_solver_rt.cu
@@ -483,17 +483,17 @@ void Radiation_solver_longwave::solve_gpu(
             }
         }
 
-        kdist_gpu->gas_optics(
-                igpt-1,
-                p_lay,
-                p_lev,
-                t_lay,
-                t_sfc,
-                gas_concs,
-                optical_props,
-                *sources,
-                col_dry,
-                t_lev);
+        //kdist_gpu->gas_optics(
+        //        igpt-1,
+        //        p_lay,
+        //        p_lev,
+        //        t_lay,
+        //        t_sfc,
+        //        gas_concs,
+        //        optical_props,
+        //        *sources,
+        //        col_dry,
+        //        t_lev);
 
         if (switch_cloud_optics)
         {
@@ -688,6 +688,7 @@ void Radiation_solver_shortwave::solve_gpu(
 
     const Array<int, 2>& band_limits_gpt(this->kdist_gpu->get_band_lims_gpoint());
     int previous_band = 0;
+    
     for (int igpt=1; igpt<=n_gpt; ++igpt)
     {
         int band = 0;
@@ -701,60 +702,43 @@ void Radiation_solver_shortwave::solve_gpu(
         }
 
         // We loop over the gas optics, due to memory constraints
-        constexpr int n_col_block = 1<<17;
+        constexpr int n_col_block = 1<<14;
 
         Array_gpu<Float,1> toa_src_temp({n_col_block});
-
         auto gas_optics_subset = [&](
-                const int col_s, const int col_e, const int n_col_subset,
-                std::unique_ptr<Optical_props_arry_rt>& optical_props_subset)
+                const int col_s, const int n_col_subset)
         {
-            Gas_concs_gpu gas_concs_subset(gas_concs, col_s, n_col_subset);
             // Run the gas_optics on a subset.
             kdist_gpu->gas_optics(
-                    igpt-1,
-                    p_lay.subset({{ {col_s, col_e}, {1, n_lay} }}),
-                    p_lev.subset({{ {col_s, col_e}, {1, n_lev} }}),
-                    t_lay.subset({{ {col_s, col_e}, {1, n_lay} }}),
-                    gas_concs_subset,
-                    optical_props_subset,
+                    igpt-1, 
+                    col_s, 
+                    n_col_subset, 
+                    n_col,
+                    p_lay,
+                    p_lev,
+                    t_lay,
+                    gas_concs,
+                    optical_props,
                     toa_src_temp,
-                    col_dry.subset({{ {col_s, col_e}, {1, n_lay} }}));
-            Subset_kernels_cuda::get_from_subset(
-                    n_col, n_lay, n_col_subset, col_s,
-                    optical_props->get_tau().ptr(), optical_props->get_ssa().ptr(), optical_props->get_g().ptr(),
-                    optical_props_subset->get_tau().ptr(), optical_props_subset->get_ssa().ptr(), optical_props_subset->get_g().ptr());
-
+                    col_dry);
         };
 
         const int n_blocks = n_col / n_col_block;
         const int n_col_residual = n_col % n_col_block;
 
-        std::unique_ptr<Optical_props_arry_rt> optical_props_block =
-                std::make_unique<Optical_props_2str_rt>(n_col_block, n_lay, *kdist_gpu);
-       
         if (n_blocks > 0)
         {
             for (int n=0; n<n_blocks; ++n)
             {
-                const int col_s = n*n_col_block + 1;
-                const int col_e = (n+1)*n_col_block;
-
-                gas_optics_subset(col_s, col_e, n_col_block, optical_props_block);
+                const int col_s = n*n_col_block;
+                gas_optics_subset(col_s, n_col_block);
             }
         }
 
-        optical_props_block.reset();
-
         if (n_col_residual > 0)
         {
-            std::unique_ptr<Optical_props_arry_rt> optical_props_residual =
-                    std::make_unique<Optical_props_2str_rt>(n_col_residual, n_lay, *kdist_gpu);
-
-            const int col_s = n_blocks*n_col_block + 1;
-            const int col_e = n_col;
-
-            gas_optics_subset(col_s, col_e, n_col_residual, optical_props_residual);
+            const int col_s = n_blocks*n_col_block;
+            gas_optics_subset(col_s, n_col_residual);
         }
 
         toa_src.fill(toa_src_temp({1}) * tsi_scaling({1}));

--- a/src_test/test_rte_rrtmgp_bw.cu
+++ b/src_test/test_rte_rrtmgp_bw.cu
@@ -269,6 +269,12 @@ void solve_radiation(int argc, char** argv)
     const bool switch_delta_cloud       = command_line_options.at("delta-cloud"      ).first;
     const bool switch_delta_aerosol     = command_line_options.at("delta-aerosol"    ).first;
 
+    if (switch_longwave)
+    {
+        std::string error = "No longwave radiation implemented in the ray tracer";
+        throw std::runtime_error(error);
+    }
+    
     // Print the options to the screen.
     print_command_line_options(command_line_options);
 

--- a/src_test/test_rte_rrtmgp_rt.cu
+++ b/src_test/test_rte_rrtmgp_rt.cu
@@ -255,8 +255,6 @@ void solve_radiation(int argc, char** argv)
     const bool switch_delta_cloud       = command_line_switches.at("delta-cloud"      ).first;
     const bool switch_delta_aerosol     = command_line_switches.at("delta-aerosol"    ).first;
 
-    // Print the options to the screen.
-    print_command_line_options(command_line_switches, command_line_ints);
 
     Int photons_per_pixel = Int(command_line_ints.at("raytracing").first);
     if (Float(int(std::log2(Float(photons_per_pixel)))) != std::log2(Float(photons_per_pixel)))
@@ -264,6 +262,15 @@ void solve_radiation(int argc, char** argv)
         std::string error = "number of photons per pixel should be a power of 2 ";
         throw std::runtime_error(error);
     }
+
+    if (switch_longwave)
+    {
+        std::string error = "No longwave radiation implemented in the ray tracer";
+        throw std::runtime_error(error);
+    }
+
+    // Print the options to the screen.
+    print_command_line_options(command_line_switches, command_line_ints);
 
     int single_gpt = command_line_ints.at("single-gpt").first;
 

--- a/src_test/test_rte_rrtmgp_rt.cu
+++ b/src_test/test_rte_rrtmgp_rt.cu
@@ -298,7 +298,7 @@ void solve_radiation(int argc, char** argv)
     Array<Float,2> t_lay(input_nc.get_variable<Float>("t_lay", {n_lay, n_col_y, n_col_x}), {n_col, n_lay});
     Array<Float,2> p_lev(input_nc.get_variable<Float>("p_lev", {n_lev, n_col_y, n_col_x}), {n_col, n_lev});
     Array<Float,2> t_lev(input_nc.get_variable<Float>("t_lev", {n_lev, n_col_y, n_col_x}), {n_col, n_lev});
-
+    
     // Fetch the col_dry in case present.
     Array<Float,2> col_dry;
     if (input_nc.variable_exists("col_dry"))


### PR DESCRIPTION
- computing grid sizes rather than reading from file was not yet implemented from file
- scaling computations are moved back to minor gas optics
- Instead of creating subsets, we save memcpy time by passing the full arrays around and instead passing subcolumn size and offset information
- Each gpoint, we only have to copy those gases that are actually used

Note: these commits change the interface to the gas optics kernels, and thus also require some modification to other code (MicroHH) calling these kernels 