### PR TITLE
initial commit: fix aerosols , remove unused function, etc.

### DIFF
--- a/include_tilt/tilt_utils.h
+++ b/include_tilt/tilt_utils.h
@@ -45,14 +45,6 @@ void post_process_output(const std::vector<ColumnResult>& col_results,
         const bool switch_liq_cloud_optics,
         const bool switch_ice_cloud_optics);
 
-bool prepare_netcdf(Netcdf_handle& input_nc, std::string file_name, int n_lay, int n_lev, int n_col_x, int n_col_y,
-                    int n_zh, int n_z, 
-                    Float sza, std::vector<Float> zh, std::vector<Float> z,
-                    Array<Float,2> p_lay, Array<Float,2> t_lay, Array<Float,2> p_lev, Array<Float,2> t_lev, 
-                    Array<Float,2> lwp, Array<Float,2> iwp, Array<Float,2> rel, Array<Float,2> dei, 
-                    Gas_concs& gas_concs, std::vector<std::string> gas_names,
-                    bool switch_cloud_optics, bool switch_liq_cloud_optics, bool switch_ice_cloud_optics);
-
 void restore_bkg_profile(const int n_x, const int n_y, 
                       const int n_full,
                       const int n_tilt, 

--- a/src_test/test_rte_rrtmgp_rt.cu
+++ b/src_test/test_rte_rrtmgp_rt.cu
@@ -469,6 +469,18 @@ void solve_radiation(int argc, char** argv)
             "aermr01", "aermr02", "aermr03", "aermr04", "aermr05", "aermr06", "aermr07", 
             "aermr08", "aermr09", "aermr10","aermr11"
         };
+
+        for (const auto& aerosol_name : aerosol_names) {
+            if (!aerosol_concs.exists(aerosol_name)) {
+                continue;
+            }
+            const Array<Float,2>& gas = aerosol_concs.get_vmr(aerosol_name);
+            if (gas.size() > 1) {
+                if (gas.get_dims()[0] == 1){
+                    aerosol_concs.set_vmr(aerosol_name, aerosol_concs.get_vmr(aerosol_name).subset({ {{1,n_col}, {1, n_lay}}} ));
+                }
+            }
+        }
         
         Array<Float,1> xh;
         Array<Float,1> yh;


### PR DESCRIPTION
The PR enables aerosols to run correctly with TICA. 

It also includes a number of fixes/edits:
- more robust checks for single profile gas/aerosol inputs
- bug fix within tilt_utils.py tilted_path() function
- deletes unused write to netcdf function
- removes stale comments

Notes:

- No relationship between azi angle and abs percent differences in scene averaged direct flux. TICA performs well at azi = 89,90,91 (close to grid alignment)
![image](https://github.com/user-attachments/assets/30493bf2-9a21-46a7-aede-b980c69f548f)
- The inclusion of aerosols adds structure to the differences in the cloud shadow free areas. Because the aerosol inputs are all single columns this must be coming from RH? I am not using aerosol fields in my work so this is not a priority for me but flagging it in case it seems concerning.
- ![image](https://github.com/user-attachments/assets/ea42c73b-2ace-4e88-bfbd-5b88d4c62a30)
- Absolute percent differences in scene averaged direct flux are still low (3% or less), but some sza have higher differences than others.  
![image](https://github.com/user-attachments/assets/484b7a6a-f3c7-4818-ae38-14a484f3dfec)

- Bug in tilted_path() function crept into to last PR in a late refactor. Bug was that new tilted segments were only triggered by boundary crossings in z. Interestingly this didn't seem to bias results much at all but it is fixed now. Found the bug because the number of layers coming out of tilted_path() was always equal to the number in. 

