### PR TITLE
initial commit

### DIFF
--- a/include_tilt/tilt_utils.h
+++ b/include_tilt/tilt_utils.h
@@ -67,16 +67,6 @@ void restore_bkg_profile_bundle(const int n_col_x, const int n_col_y,
     bool switch_liq_cloud_optics, bool switch_ice_cloud_optics, bool switch_aerosol_optics
     );
 
-void compress_columns_weighted_avg(const int n_x, const int n_y,  
-                      const int n_out, 
-                      const int n_tilt,
-                      const int compress_lay_start_idx,
-                      std::vector<Float>& var, std::vector<Float>& var_weighting);
-
-void compress_columns_p_or_t(const int n_x, const int n_y, 
-                      const int n_out_lay,  const int n_tilt,
-                      const int compress_lay_start_idx,
-                      std::vector<Float>& var_lev, std::vector<Float>& var_lay);
 
 void tilt_fields(const int n_z_in, const int n_zh_in, const int n_col_x, const int n_col_y,
     const int n_z_tilt, const int n_zh_tilt, const int n_col,
@@ -87,13 +77,6 @@ void tilt_fields(const int n_z_in, const int n_zh_in, const int n_col_x, const i
     Gas_concs& gas_concs_copy, const std::vector<std::string> gas_names,
     Aerosol_concs& aerosol_concs_copy, const std::vector<std::string> aerosol_names, const bool switch_aerosol_optics
     );
-
-void compress_fields(const int compress_lay_start_idx, const int n_col_x, const int n_col_y,
-    const int n_z_in, const int n_zh_in,  const int n_z_tilt,
-    Array<Float,2>* p_lay_copy, Array<Float,2>* t_lay_copy, Array<Float,2>* p_lev_copy, Array<Float,2>* t_lev_copy, 
-    Array<Float,2>* rh_copy, 
-    Gas_concs& gas_concs_copy, std::vector<std::string> gas_names,
-    Aerosol_concs& aerosol_concs_copy, std::vector<std::string> aerosol_names, const bool switch_aerosol_optics);
 
 void create_tilted_columns(const int n_x, const int n_y, const int n_lay_in, const int n_lev_in,
                            const std::vector<Float>& zh_tilted, const std::vector<ijk>& tilted_path,

--- a/src_tilt/tilt_utils.cpp
+++ b/src_tilt/tilt_utils.cpp
@@ -586,6 +586,10 @@ void tica_tilt(
     bool switch_cloud_optics, bool switch_liq_cloud_optics, bool switch_ice_cloud_optics, bool switch_aerosol_optics
 )
 {
+        const Float sza_deg = sza * 180. / M_PI;
+        if (sza_deg > 75.0) {
+            throw std::runtime_error("SZA too high for TICA tilting.");
+        }
        // if t lev all 0, interpolate from t lay
        if (*std::max_element(t_lev_out.v().begin(), t_lev_out.v().end()) <= 0) {
        for (int i = 1; i <= n_col; ++i) {


### PR DESCRIPTION
I'm proposing using the skipping boundary crossings in x and y as our compression algorithm over the previous manual one. Skipping boundary crossings in x and y works to "compress" the tilted field as the number of layers out is always equal to the number in. Rather than merge vertical layers from the top down, we only record values and create new path segments when a z boundary is crossed. This distributes the compression randomly throughout the column rather than starting at the top.

The key change is here:
```
--   if ((std::abs(l - lx) < epsilon) ||  (std::abs(l - ly) < epsilon) || ( (std::abs(l - lz) < epsilon || zp >= zh[k+1]))){
++   if ( (std::abs(l - lz) < epsilon || zp >= zh[k+1])){
            // Create a new path segment after crossing boundary
            tilted_path.push_back({i, j, k});
            dz_tilted.push_back(0.0);
}
```
![image](https://github.com/user-attachments/assets/acc9ff4e-3ec4-4f05-839e-f9c51ce7bcae)
It would skip the boundary crossings and values for the pixels highlighted. Those segments still count toward the path length of the previous value.

I was motivated to look into this after than errors we saw in the aerosol PR:
![image](https://github.com/user-attachments/assets/eb4045f1-eb10-48ef-9247-9a0a9a1c9be1)


Now, with this change we don't have higher percent differences with the 3D direct surface field for some solar zenith angles:
![image](https://github.com/user-attachments/assets/df1f5590-abee-4146-bf16-41e0663f5499)

In fact, the simplified TICA has lower errors overall for runs with and without aerosols. It also has the added benefits of:

- simpler, more readable code (100s of lines fewer)
- runs faster

Finally, the simplified TICA can be run for theta greater than 70 degrees, but percent absolute errors increase dramatically after ~75 degrees:
![image](https://github.com/user-attachments/assets/6b26dda2-5a3b-44e5-af04-f2829e7815a4)
