### PR TITLE
Skip Monte Carlo computations for g-points with high gasous optical depths

### DIFF
--- a/include_test/radiation_solver_rt.h
+++ b/include_test/radiation_solver_rt.h
@@ -54,6 +54,7 @@ class Radiation_solver_longwave
                 const bool switch_lw_scattering,
                 const bool switch_independent_column,
                 const int single_gpt,
+                const Float tau_frac_threshold,
                 const Int ray_count,
                 const Vector<int> grid_cells,
                 const Vector<Float> grid_d,

--- a/include_test/radiation_solver_rt.h
+++ b/include_test/radiation_solver_rt.h
@@ -54,7 +54,7 @@ class Radiation_solver_longwave
                 const bool switch_lw_scattering,
                 const bool switch_independent_column,
                 const int single_gpt,
-                const Float tau_frac_threshold,
+                const Float min_mfp_grid_ratio,
                 const Int ray_count,
                 const Vector<int> grid_cells,
                 const Vector<Float> grid_d,

--- a/src_cuda_rt/raytracer_lw.cu
+++ b/src_cuda_rt/raytracer_lw.cu
@@ -297,12 +297,6 @@ void Raytracer_lw::trace_rays(
     Array_gpu<Float,2> surface_up_count({grid_cells.x, grid_cells.y});
     Array_gpu<Float,3> atmos_count({grid_cells.x, grid_cells.y, grid_cells.z});
 
-    Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(grid_cells.x, grid_cells.y, flux_tod_dn.ptr());
-    Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(grid_cells.x, grid_cells.y, flux_tod_up.ptr());
-    Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(grid_cells.x, grid_cells.y, flux_sfc_dn.ptr());
-    Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(grid_cells.x, grid_cells.y, flux_sfc_up.ptr());
-    Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(grid_cells.x, grid_cells.y, grid_cells.z, flux_abs.ptr());
-
     // domain sizes
     const Vector<Float> grid_size = grid_d * grid_cells;
 

--- a/src_kernels_cuda_rt/raytracer_kernels_lw.cu
+++ b/src_kernels_cuda_rt/raytracer_kernels_lw.cu
@@ -146,7 +146,7 @@ namespace
             {
                 const int idx = sample_alias_table(
                         alias_prob, alias_idx, alias_n,
-                        Float(rng()), Float(rng()));
+                        alias_rng(), alias_rng());
 
                 const int i = idx % grid_cells.x ;
                 const int j = idx / grid_cells.x ;
@@ -166,7 +166,7 @@ namespace
             {
                 const int idx = sample_alias_table(
                         alias_prob, alias_idx, alias_n,
-                        Float(rng()), Float(rng()));
+                        alias_rng(), alias_rng());
 
                 const int i = idx % grid_cells.x ;
                 const int j = idx / grid_cells.x ;

--- a/src_test/radiation_solver_rt.cu
+++ b/src_test/radiation_solver_rt.cu
@@ -643,6 +643,11 @@ void Radiation_solver_longwave::solve_gpu(
 
             if (switch_raytracing)
             {
+                Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(grid_cells.x, grid_cells.y, (*fluxes).get_flux_tod_dn().ptr());
+                Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(grid_cells.x, grid_cells.y, (*fluxes).get_flux_tod_up().ptr());
+                Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(grid_cells.x, grid_cells.y, (*fluxes).get_flux_sfc_dif().ptr());
+                Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(grid_cells.x, grid_cells.y, (*fluxes).get_flux_sfc_up().ptr());
+                Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(grid_cells.x, grid_cells.y, grid_cells.z, (*fluxes).get_flux_abs_dif().ptr());
 
                 raytracer_lw.trace_rays(
                         igpt,

--- a/src_test/radiation_solver_rt.cu
+++ b/src_test/radiation_solver_rt.cu
@@ -34,7 +34,7 @@
 #include "fluxes_rt.h"
 #include "rte_lw_rt.h"
 #include "rte_sw_rt.h"
-
+#include "cub/cub.cuh"
 #include "subset_kernels_cuda.h"
 #include "gas_optics_rrtmgp_kernels_cuda_rt.h"
 #include "gpt_combine_kernels_cuda_rt.h"
@@ -42,28 +42,94 @@
 
 namespace
 {
-        __global__
-        void scale_tau_kernel(Float* tau, const int ncol, const int nlay, Float scale_factor) {
-                const int icol = blockIdx.x*blockDim.x + threadIdx.x;
-                const int ilay = blockIdx.y*blockDim.y + threadIdx.y;
+    __global__
+    void convert_1d_to_rt_hr_kernels(
+        const int ncol,
+        const int nz,
+        const Float dz,
+        const Float* flux_net,
+        Float* flux_rt_abs)
+    {
+        const int icol = blockIdx.x*blockDim.x + threadIdx.x;
+        const int iz = blockIdx.y*blockDim.y + threadIdx.y;
 
-                if ( (icol < ncol) && (ilay < nlay) )
-                {
+        if ( (icol < ncol) && (iz < nz) )
+        {
+            const int idx = icol + iz*ncol;
+            const int idx_p = icol + (iz+1)*ncol;
+
+            flux_rt_abs[idx] = (flux_net[idx_p] - flux_net[idx])/dz;
+        }
+    }
+
+    __global__
+    void convert_1d_to_rt_flx_kernels(
+        const int ncol,
+        const int iz,
+        const Float* flux_1d_dn,
+        const Float* flux_1d_up,
+        Float* flux_rt_dn,
+        Float* flux_rt_up)
+    {
+        const int icol = blockIdx.x*blockDim.x + threadIdx.x;
+
+        if (icol < ncol)
+        {
+            const int idx_in = icol + iz*ncol;
+            flux_rt_dn[icol] = flux_1d_dn[idx_in];
+            flux_rt_up[icol] = flux_1d_up[idx_in];
+        }
+    }
+
+    void convert_1d_to_rt_output(
+        const int ncol,
+        const int nlay,
+        const int nz,
+        const Float dz,
+        const Array_gpu<Float,2>& flux_up,
+        const Array_gpu<Float,2>& flux_dn,
+        const Array_gpu<Float,2>& flux_net,
+        Array_gpu<Float,2>& flux_tod_dn,
+        Array_gpu<Float,2>& flux_tod_up,
+        Array_gpu<Float,2>& flux_sfc_dn,
+        Array_gpu<Float,2>& flux_sfc_up,
+        Array_gpu<Float,3>& flux_abs)
+    {
+        const int block_col = 64;
+        const int grid_col = ncol/block_col + (ncol%block_col > 0);
+
+        convert_1d_to_rt_flx_kernels<<<grid_col, block_col>>>(ncol, 0, flux_dn.ptr(), flux_up.ptr(), flux_sfc_dn.ptr(), flux_sfc_up.ptr());
+        convert_1d_to_rt_flx_kernels<<<grid_col, block_col>>>(ncol, nz+1, flux_dn.ptr(), flux_up.ptr(), flux_tod_dn.ptr(), flux_tod_up.ptr());
+
+        const dim3 block_2d(block_col, 1, 1);
+        const dim3 grid_2d(grid_col, nz, 1);
+        convert_1d_to_rt_hr_kernels<<<grid_2d, block_2d>>>(
+            ncol, nz, dz, flux_net.ptr(), flux_abs.ptr());
+    }
+
+
+    __global__
+    void scale_tau_kernel(Float* tau, const int ncol, const int nlay, Float scale_factor) {
+            const int icol = blockIdx.x*blockDim.x + threadIdx.x;
+            const int ilay = blockIdx.y*blockDim.y + threadIdx.y;
+
+            if ( (icol < ncol) && (ilay < nlay) )
+            {
                 const int idx = icol + ilay*ncol;
                 tau[idx] = tau[idx] * scale_factor;
-                }
-        }
+            }
+    }
 
-        void scale_tau(Float* tau, const int ncol, const int nlay, Float scale_factor) {
-                const int block_col = 64;
-                const int block_lay = 1;
-                const int grid_col  = ncol/block_col + (ncol%block_col > 0);
-                const int grid_lay  = nlay/block_lay + (nlay%block_lay > 0);
+    void scale_tau(Float* tau, const int ncol, const int nlay, Float scale_factor) {
+            const int block_col = 64;
+            const int block_lay = 1;
+            const int grid_col  = ncol/block_col + (ncol%block_col > 0);
+            const int grid_lay  = nlay/block_lay + (nlay%block_lay > 0);
 
-                dim3 grid_gpu(grid_col, grid_lay);
-                dim3 block_gpu(block_col, block_lay);
-                scale_tau_kernel<<<grid_gpu, block_gpu>>>(tau, ncol, nlay, scale_factor);
-        }
+            dim3 grid_gpu(grid_col, grid_lay);
+            dim3 block_gpu(block_col, block_lay);
+            scale_tau_kernel<<<grid_gpu, block_gpu>>>(tau, ncol, nlay, scale_factor);
+    }
 
     std::vector<std::string> get_variable_string(
             const std::string& var_name,
@@ -421,6 +487,7 @@ void Radiation_solver_longwave::solve_gpu(
         const bool switch_lw_scattering,
         const bool switch_independent_column,
         const int single_gpt,
+        const Float tau_frac_threshold,
         const Int ray_count,
         const Vector<int> grid_cells,
         const Vector<Float> grid_d,
@@ -534,6 +601,29 @@ void Radiation_solver_longwave::solve_gpu(
         }
 
 
+        // Allocate temporary storage
+        void* d_temp_storage = nullptr;
+        size_t temp_storage_bytes = 0;
+
+        const int max_size = n_col * grid_cells.z;
+
+        Float* max_tau_gas_g = Tools_gpu::allocate_gpu<Float>(1);
+        Float* max_tau_cld_g = Tools_gpu::allocate_gpu<Float>(1);
+        Float max_tau_gas = 0;
+        Float max_tau_cld = 0;
+
+        // Get required temp storage size
+        cub::DeviceReduce::Max(d_temp_storage, temp_storage_bytes,
+                               optical_props->get_tau().ptr(), max_tau_gas_g, max_size);
+
+        // Allocate temp storage
+        cudaMalloc(&d_temp_storage, temp_storage_bytes);
+
+        // Compute max
+        cub::DeviceReduce::Max(d_temp_storage, temp_storage_bytes,
+                               optical_props->get_tau().ptr(), max_tau_gas_g, max_size);
+
+        cudaMemcpy(&max_tau_gas, max_tau_gas_g, sizeof(Float), cudaMemcpyDeviceToHost);
 
         if (switch_cloud_optics)
         {
@@ -550,6 +640,11 @@ void Radiation_solver_longwave::solve_gpu(
                 // cloud->delta_scale();
 
             }
+            // Compute max
+            cub::DeviceReduce::Max(d_temp_storage, temp_storage_bytes,
+                                   cloud_optical_props->get_tau().ptr(), max_tau_cld_g, max_size);
+            cudaMemcpy(&max_tau_cld, max_tau_cld_g, sizeof(Float), cudaMemcpyDeviceToHost);
+
             // Add the cloud optical props to the gas optical properties.
             add_to(
                     dynamic_cast<Optical_props_2str_rt&>(*optical_props),
@@ -649,30 +744,47 @@ void Radiation_solver_longwave::solve_gpu(
                 Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(grid_cells.x, grid_cells.y, (*fluxes).get_flux_sfc_up().ptr());
                 Gas_optics_rrtmgp_kernels_cuda_rt::zero_array(grid_cells.x, grid_cells.y, grid_cells.z, (*fluxes).get_flux_abs_dif().ptr());
 
-                raytracer_lw.trace_rays(
-                        igpt,
-                        switch_independent_column,
-                        ray_count,
-                        grid_cells,
-                        grid_d,
-                        kn_grid,
-                        dynamic_cast<Optical_props_2str_rt&>(*optical_props).get_tau(),
-                        dynamic_cast<Optical_props_2str_rt&>(*optical_props).get_ssa(),
-                        dynamic_cast<Optical_props_2str_rt&>(*cloud_optical_props).get_tau(),
-                        dynamic_cast<Optical_props_2str_rt&>(*cloud_optical_props).get_ssa(),
-                        dynamic_cast<Optical_props_2str_rt&>(*cloud_optical_props).get_g(),
-                        dynamic_cast<Optical_props_2str_rt&>(*aerosol_optical_props).get_tau(),
-                        dynamic_cast<Optical_props_2str_rt&>(*aerosol_optical_props).get_ssa(),
-                        dynamic_cast<Optical_props_2str_rt&>(*aerosol_optical_props).get_g(),
-                        (*sources).get_lay_source(),
-                        (*sources).get_sfc_source(),
-                        emis_sfc,
-                        (*fluxes).get_flux_dn()({1, grid_cells.z}),
+                if ( ((max_tau_gas / max_tau_cld) < tau_frac_threshold) || (tau_frac_threshold < 0) )
+                {
+                    raytracer_lw.trace_rays(
+                            igpt,
+                            switch_independent_column,
+                            ray_count,
+                            grid_cells,
+                            grid_d,
+                            kn_grid,
+                            dynamic_cast<Optical_props_2str_rt&>(*optical_props).get_tau(),
+                            dynamic_cast<Optical_props_2str_rt&>(*optical_props).get_ssa(),
+                            dynamic_cast<Optical_props_2str_rt&>(*cloud_optical_props).get_tau(),
+                            dynamic_cast<Optical_props_2str_rt&>(*cloud_optical_props).get_ssa(),
+                            dynamic_cast<Optical_props_2str_rt&>(*cloud_optical_props).get_g(),
+                            dynamic_cast<Optical_props_2str_rt&>(*aerosol_optical_props).get_tau(),
+                            dynamic_cast<Optical_props_2str_rt&>(*aerosol_optical_props).get_ssa(),
+                            dynamic_cast<Optical_props_2str_rt&>(*aerosol_optical_props).get_g(),
+                            (*sources).get_lay_source(),
+                            (*sources).get_sfc_source(),
+                            emis_sfc,
+                            (*fluxes).get_flux_dn()({1, grid_cells.z}),
+                            (*fluxes).get_flux_tod_dn(),
+                            (*fluxes).get_flux_tod_up(),
+                            (*fluxes).get_flux_sfc_dif(),
+                            (*fluxes).get_flux_sfc_up(),
+                            (*fluxes).get_flux_abs_dif());
+                }
+                else
+                {
+                    convert_1d_to_rt_output(
+                        n_col, n_lay, grid_cells.z, grid_d.z,
+                        (*fluxes).get_flux_up(),
+                        (*fluxes).get_flux_dn(),
+                        (*fluxes).get_flux_net(),
                         (*fluxes).get_flux_tod_dn(),
                         (*fluxes).get_flux_tod_up(),
                         (*fluxes).get_flux_sfc_dif(),
                         (*fluxes).get_flux_sfc_up(),
                         (*fluxes).get_flux_abs_dif());
+
+                }
 
                 Gpt_combine_kernels_cuda_rt::add_from_gpoint(
                         grid_cells.x, grid_cells.y,

--- a/src_test/test_rte_rrtmgp_rt.cu
+++ b/src_test/test_rte_rrtmgp_rt.cu
@@ -731,6 +731,7 @@ void solve_radiation(int argc, char** argv)
                     switch_lw_scattering,
                     switch_independent_column,
                     single_gpt,
+                    tau_frac_threshold,
                     photons_per_pixel,
                     grid_cells,
                     grid_d,

--- a/src_test/test_rte_rrtmgp_rt.cu
+++ b/src_test/test_rte_rrtmgp_rt.cu
@@ -241,13 +241,13 @@ void solve_radiation(int argc, char** argv)
         {"profiling"         , { false, "Perform additional profiling run."         }},
         {"delta-cloud"       , { false, "delta-scaling of cloud optical properties"   }},
         {"delta-aerosol"     , { false, "delta-scaling of aerosol optical properties"   }},
-        {"tau-frac-threshold", { true,  "Skip ray tracing and use 1D solution above given ratio between highest per-cell gas and cloud optical depths. Default: '--tau-frac-threshold 0.1'" }},
+        {"min-mfp-grid-ratio", { true,  "Lowest ratio between the shortest gasous mean free path and the smallest grid dimension at which we still do ray tracing. Below this ratio, the 1D solution is used. '--min-mfp-grid-ratio 1'" }},
         {"tica"              , { false, "attenuate path when doing an overhead 1D calculation of tilted input"   }}};
 
     std::map<std::string, Float> command_line_numbers {
         {"raytracing", 32},
         {"single-gpt", 1},
-        {"tau-frac-threshold", 0.1}};
+        {"min-mfp-grid-ratio", 1}};
 
     if (parse_command_line_options(command_line_switches, command_line_numbers, argc, argv))
         return;
@@ -262,7 +262,7 @@ void solve_radiation(int argc, char** argv)
     bool switch_liq_cloud_optics  = command_line_switches.at("liq-cloud-optics"  ).first;
     bool switch_ice_cloud_optics  = command_line_switches.at("ice-cloud-optics"  ).first;
     const bool switch_lw_scattering     = command_line_switches.at("lw-scattering"     ).first;
-    const bool switch_tau_frac_threshold= command_line_switches.at("tau-frac-threshold").first;
+    const bool switch_min_mfp_grid_ratio= command_line_switches.at("min-mfp-grid-ratio").first;
     const bool switch_cloud_mie         = command_line_switches.at("cloud-mie"         ).first;
     const bool switch_aerosol_optics    = command_line_switches.at("aerosol-optics"    ).first;
     const bool switch_single_gpt        = command_line_switches.at("single-gpt"        ).first;
@@ -309,7 +309,7 @@ void solve_radiation(int argc, char** argv)
 
     int single_gpt = int(command_line_numbers.at("single-gpt"));
 
-    const Float tau_frac_threshold = switch_tau_frac_threshold ? command_line_numbers.at("tau-frac-threshold") : Float(-1.);
+    const Float min_mfp_grid_ratio = switch_min_mfp_grid_ratio ? command_line_numbers.at("min-mfp-grid-ratio") : Float(0.);
 
     Status::print_message("Using "+ std::to_string(photons_per_pixel) + " rays per pixel");
 
@@ -731,7 +731,7 @@ void solve_radiation(int argc, char** argv)
                     switch_lw_scattering,
                     switch_independent_column,
                     single_gpt,
-                    tau_frac_threshold,
+                    min_mfp_grid_ratio,
                     photons_per_pixel,
                     grid_cells,
                     grid_d,

--- a/src_test/test_rte_rrtmgp_rt.cu
+++ b/src_test/test_rte_rrtmgp_rt.cu
@@ -131,7 +131,7 @@ void configure_memory_pool(int nlays, int ncols, int nchunks, int ngpts, int nbn
 
 bool parse_command_line_options(
         std::map<std::string, std::pair<bool, std::string>>& command_line_switches,
-        std::map<std::string, std::pair<int, std::string>>& command_line_ints,
+        std::map<std::string, Float>& command_line_numbers,
         int argc, char** argv)
 {
     for (int i=1; i<argc; ++i)
@@ -179,21 +179,21 @@ bool parse_command_line_options(
             command_line_switches.at(argument).first = enable;
         }
 
-        // Check if a is integer is too be expect and if so, supplied
-        if (command_line_ints.find(argument) != command_line_ints.end() && i+1 < argc)
+        // Check if a is number (int of float) and hether that ir is too be expect and if so, supplied
+        if (command_line_numbers.find(argument) != command_line_numbers.end() && i+1 < argc)
         {
-            std::string next_argument(argv[i+1]);
-            boost::trim(next_argument);
-
-            bool arg_is_int = true;
-            for (int j=0; j<next_argument.size(); ++j)
-                arg_is_int *= std::isdigit(next_argument[j]);
-
-            if (arg_is_int)
+            try
             {
-                command_line_ints.at(argument).first = std::stoi(argv[i+1]);
-                ++i;
+                size_t p;
+                Float val = Float(std::stod(argv[i+1], &p));
+                if (p == strlen(argv[i+1]))
+                {
+                    command_line_numbers.at(argument) = Float(std::stod(argv[i+1]));
+                    ++i;
+                }
+
             }
+            catch(...){}
         }
     }
 
@@ -202,15 +202,15 @@ bool parse_command_line_options(
 
 void print_command_line_options(
         const std::map<std::string, std::pair<bool, std::string>>& command_line_switches,
-        const std::map<std::string, std::pair<int, std::string>>& command_line_ints)
+        const std::map<std::string, Float>& command_line_numbers)
 {
     Status::print_message("Solver settings:");
     for (const auto& option : command_line_switches)
     {
         std::ostringstream ss;
         ss << std::left << std::setw(20) << (option.first);
-        if (command_line_ints.find(option.first) != command_line_ints.end() && option.second.first)
-            ss << " = " << std::boolalpha << command_line_ints.at(option.first).first << std::endl;
+        if (command_line_numbers.find(option.first) != command_line_numbers.end() && option.second.first)
+            ss << " = " << std::boolalpha << command_line_numbers.at(option.first) << std::endl;
         else
             ss << " = " << std::boolalpha << option.second.first << std::endl;
         Status::print_message(ss);
@@ -229,7 +229,7 @@ void solve_radiation(int argc, char** argv)
         {"longwave"          , { false, "Enable computation of longwave radiation." }},
         {"fluxes"            , { true,  "Enable computation of fluxes."             }},
         {"two-stream"        , { true, "Run two-stream solver for to obtain 1D fluxes" }},
-        {"raytracing"        , { true,  "Use raytracing for flux computation. '--raytracing 256': use 256 rays per pixel" }},
+        {"raytracing"        , { true,  "Use raytracing for flux computation. '--raytracing 256': use 256 rays per pixel per spectral quadrature point" }},
         {"independent-column", { false, "run raytracer in independent column mode"}},
         {"cloud-optics"      , { false, "Enable cloud optics (both liquid and ice)."}},
         {"liq-cloud-optics"  , { false, "liquid only cloud optics."                 }},
@@ -241,13 +241,15 @@ void solve_radiation(int argc, char** argv)
         {"profiling"         , { false, "Perform additional profiling run."         }},
         {"delta-cloud"       , { false, "delta-scaling of cloud optical properties"   }},
         {"delta-aerosol"     , { false, "delta-scaling of aerosol optical properties"   }},
+        {"tau-frac-threshold", { true,  "Skip ray tracing and use 1D solution above given ratio between highest per-cell gas and cloud optical depths. Default: '--tau-frac-threshold 0.1'" }},
         {"tica"              , { false, "attenuate path when doing an overhead 1D calculation of tilted input"   }}};
 
-    std::map<std::string, std::pair<int, std::string>> command_line_ints {
-        {"raytracing", {32, "Number of rays initialised at TOD per pixel per quadraute."}},
-        {"single-gpt", {1 , "g-point to store optical properties and fluxes of" }}};
+    std::map<std::string, Float> command_line_numbers {
+        {"raytracing", 32},
+        {"single-gpt", 1},
+        {"tau-frac-threshold", 0.1}};
 
-    if (parse_command_line_options(command_line_switches, command_line_ints, argc, argv))
+    if (parse_command_line_options(command_line_switches, command_line_numbers, argc, argv))
         return;
 
     const bool switch_shortwave         = command_line_switches.at("shortwave"         ).first;
@@ -260,6 +262,7 @@ void solve_radiation(int argc, char** argv)
     bool switch_liq_cloud_optics  = command_line_switches.at("liq-cloud-optics"  ).first;
     bool switch_ice_cloud_optics  = command_line_switches.at("ice-cloud-optics"  ).first;
     const bool switch_lw_scattering     = command_line_switches.at("lw-scattering"     ).first;
+    const bool switch_tau_frac_threshold= command_line_switches.at("tau-frac-threshold").first;
     const bool switch_cloud_mie         = command_line_switches.at("cloud-mie"         ).first;
     const bool switch_aerosol_optics    = command_line_switches.at("aerosol-optics"    ).first;
     const bool switch_single_gpt        = command_line_switches.at("single-gpt"        ).first;
@@ -268,8 +271,7 @@ void solve_radiation(int argc, char** argv)
     const bool switch_delta_aerosol     = command_line_switches.at("delta-aerosol"     ).first;
     const bool switch_tica              = command_line_switches.at("tica"     ).first;
 
-    Int photons_per_pixel = Int(command_line_ints.at("raytracing").first);
-
+    Int photons_per_pixel = Int(command_line_numbers.at("raytracing"));
     if (Float(int(std::log2(Float(photons_per_pixel)))) != std::log2(Float(photons_per_pixel)))
     {
         std::string error = "number of photons per pixel should be a power of 2 ";
@@ -303,9 +305,11 @@ void solve_radiation(int argc, char** argv)
     }
 
     // Print the options to the screen.
-    print_command_line_options(command_line_switches, command_line_ints);
+    print_command_line_options(command_line_switches, command_line_numbers);
 
-    int single_gpt = command_line_ints.at("single-gpt").first;
+    int single_gpt = int(command_line_numbers.at("single-gpt"));
+
+    const Float tau_frac_threshold = switch_tau_frac_threshold ? command_line_numbers.at("tau-frac-threshold") : Float(-1.);
 
     Status::print_message("Using "+ std::to_string(photons_per_pixel) + " rays per pixel");
 


### PR DESCRIPTION
G-points with high gaseous optical depth barely show any impact of clouds, but introduce a significant amount of noise. User can define a threshold ratio between the maximum gas and cloud optical depths (per-cell, not vertically integrated). If the ratio exceeds this threshold, use 1D fluxes instead of MC ray tracing. This threshold defaults to 0.1, in which case less than half of the g-points are run in 3D